### PR TITLE
add ajax to post message function

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,3 +53,5 @@ gem 'pry-rails'
 gem 'carrierwave'
 
 gem 'mini_magick'
+
+gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,10 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.4.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -294,6 +298,7 @@ DEPENDENCIES
   font-awesome-sass
   haml-rails (>= 1.0, <= 2.0.1)
   jbuilder (~> 2.7)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
+//= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,3 @@
+//= require jquery
+//= require rails-ujs
+//= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,40 @@
 $(function() {
+  function buildHTML(message) {
+    if (message.image) {
+      let html =
+        `<div class="Message-box">
+          <div class="Message-info">
+            <div class="Message-info__user-name">
+              ${message.user_name}
+            </div>
+            <div class="Message-info__date">
+              ${message.created_at}
+            </div>
+          </div>
+          <p class="Message-box__message">
+            ${message.message}
+          </p>
+          <img class="Message__image" src="${message.image}">
+        </div>` 
+      return html;
+    } else {
+      let html =
+      `<div class="Message-box">
+        <div class="Message-info">
+          <div class="Message-info__user-name">
+            ${message.user_name}
+          </div>
+          <div class="Message-info__date">
+            ${message.created_at}
+          </div>
+        </div>
+        <p class="Message-box__message">
+          ${message.message}
+          </p>
+          </div>`
+      return html
+    }
+  }
   $('.Form').on('submit', function(e) {
     e.preventDefault()
     let formData = new FormData(this);
@@ -10,6 +46,9 @@ $(function() {
       dataType: 'json',
       processData: false,
       contentType: false
+    })
+    .done(function(data){
+      let html = buildHTML(data);
     })
   })
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -14,7 +14,7 @@ $(function() {
           <p class="Message-box__message">
             ${message.message}
           </p>
-          <img class="Message__image" src="${message.image}">
+          <img class="Message-box__image" src="${message.image}">
         </div>` 
       return html;
     } else {
@@ -52,7 +52,7 @@ $(function() {
       $('.Main-chat__message-list').append(html);
       $('.Main-chat__message-list').animate({ scrollTop: $('.Main-chat__message-list')[0].scrollHeight});
       $('form')[0].reset();
-      $('form').prop('disabled', false);
+      $('input').prop('disabled', false);
     })
     .fail(function() {
       alert("メッセージ送信に失敗しました");

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -50,7 +50,8 @@ $(function() {
     .done(function(data){
       let html = buildHTML(data);
       $('.Main-chat__message-list').append(html);
-      $('.Form')[0].reset();
+      $('.Main-chat__message-list').animate({ scrollTop: $('.Main-chat__message-list')[0].scrollHeight});
+      $('form')[0].reset();
     })
   })
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,3 +1,6 @@
-$(function(){
-  console.log("message.js読み込み成功")
+$(function() {
+  $('.Form').on('submit', function(e) {
+    e.preventDefault()
+    console.log("フォームの送信を確認");
+  })
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -54,5 +54,8 @@ $(function() {
       $('form')[0].reset();
       $('form').prop('disabled', false);
     })
+    .fail(function() {
+      alert("メッセージ送信に失敗しました");
+    });
   })
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -52,6 +52,7 @@ $(function() {
       $('.Main-chat__message-list').append(html);
       $('.Main-chat__message-list').animate({ scrollTop: $('.Main-chat__message-list')[0].scrollHeight});
       $('form')[0].reset();
+      $('form').prop('disabled', false);
     })
   })
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,16 @@
 $(function() {
   $('.Form').on('submit', function(e) {
     e.preventDefault()
-    console.log("フォームの送信を確認");
+    let formData = new FormData(this);
+    let url = $(this).attr('action')
+    console.log(formData);
+    $.ajax({
+      url: url,
+      type: 'POST',
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
   })
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -3,7 +3,6 @@ $(function() {
     e.preventDefault()
     let formData = new FormData(this);
     let url = $(this).attr('action')
-    console.log(formData);
     $.ajax({
       url: url,
       type: 'POST',

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -49,6 +49,8 @@ $(function() {
     })
     .done(function(data){
       let html = buildHTML(data);
+      $('.Main-chat__message-list').append(html);
+      $('.Form')[0].reset();
     })
   })
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,3 @@
+$(function(){
+  console.log("message.js読み込み成功")
+});

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,9 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,7 @@
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.message @message.message
+json.image @message.image_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,6 @@ module ChatSpace
     end
     
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
# What
ChatSpaceのメッセージ送信機能の非同期通信化

# Why
非同期通信化によりメッセージ送信時のビューの再描画をなくすため。

以下の流れに沿って実装する
1. 新しいブランチを作成する
1. JavaScriptとjQueryを使用するための準備をする
1. これから記述するjsファイルを作成して、jQueryが読み込めることを確認する
1. フォームが送信されたら、イベントが発火するようにする
1. イベントが発火したときにAjaxを使用して、messages#createが動くようにする
1. messages#createでメッセージを保存し、respond_toを使用してHTMLとJSONの場合で処理を分ける
1. jbuilderを使用して、作成したメッセージをJSON形式で返す
1. 返ってきたJSONをdoneメソッドで受取り、HTMLを作成する
1. 作成したHTMLをメッセージ画面の一番下に追加する
1. メッセージを送信したとき、メッセージ画面を最下部にスクロールする
1. 連続で送信ボタンを押せるようにする
1. 非同期に失敗した場合の処理も準備する
